### PR TITLE
Update Dockerfile to set $HOME variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV https_proxy http://9.196.156.29:3128
 RUN python3 -m venv /usr/src/node-red/venv --system-site-packages
 #RUN useradd -m -l -d /home/nodered -u 1000730033 -g 0 nodered -p abc1234
 USER nodered
+ENV HOME /usr/src/node-red
 WORKDIR /usr/src/node-red
-CMD sleep 60000
-#CMD node-red /usr/src/node-red/sales-manual-reader-flow.json
+#CMD sleep 60000
+CMD node-red /usr/src/node-red/sales-manual-reader-flow.json


### PR DESCRIPTION
Updates to Dockerfile to set the $HOME variable that Node-Red uses when starting up.
This gets Node-Red running correctly for me, with the right flows loaded, and I can load the /bot page. I have not done any further testing.
Over to you.